### PR TITLE
Updating the OAuth 2.0 Scope Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ dump.rdb
 transaction-logs
 docker-build-local.sh
 *.tar
+.vscode

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This microservice is designed to be used with other microservices. Please look a
 
 This microservice is configurable so that it can be secured via an OAuth 2 provider.
 
-__Scopes__: This application uses the following scope: `hl7-utils.*`
+__Scopes__: This application uses the following scope: `fdns.hl7-utils.{profile}.{create|read|update|delete}`. Example: `fdns.hl7-utils.myprofile.read`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,10 @@
 version: '3.1'
 services:
-  mongo:
-    image: mongo
-    ports:
-      - "27017:27017"
   fluentd:
     image: fluent/fluentd
     ports:
       - "24224:24224"
-  fdns-ms-object:
-    image: cdcgov/fdns-ms-object
+  fdns-ms-stubbing:
+    image: cdcgov/fdns-ms-stubbing
     ports:
-      - "8083:8083"
-    environment:
-      OBJECT_PORT: 8083
+      - "3002:3002" 

--- a/src/main/java/gov/cdc/foundation/controller/HL7Controller.java
+++ b/src/main/java/gov/cdc/foundation/controller/HL7Controller.java
@@ -15,7 +15,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,27 +85,50 @@ public class HL7Controller {
 		}
 	}
 	
-	@RequestMapping(value = "json", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.TEXT_PLAIN_VALUE)
-	@ApiOperation(value = "Transform HL7 to JSON", notes = "Transforms an HL7 message to JSON object.")
+	@RequestMapping(
+		value = "json",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.TEXT_PLAIN_VALUE
+	)
+	@ApiOperation(
+		value = "Transform HL7 to JSON",
+		notes = "Transforms an HL7 message to JSON object."
+	)
 	@ResponseBody
 	public ResponseEntity<?> transformHL7toJSON(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String message, 
-			@ApiParam(value = "Spec (HL7 or PHIN)", allowableValues = "hl7,phinms") @RequestParam(value = "spec", required = false) String spec) {
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String message, 
+		@ApiParam(value = "Spec (HL7 or PHIN)", allowableValues = "hl7,phinms") @RequestParam(value = "spec", required = false) String spec
+	) {
 		return transformHL7toJSON(authorizationHeader, message, spec, null);
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('hl7-utils:'.concat(#profile))")
-	@RequestMapping(value = "json/{profile}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.TEXT_PLAIN_VALUE)
-	@ApiOperation(value = "Transform HL7 to JSON", notes = "Transforms an HL7 message to JSON object using a profile.")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.read')"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.*')"
+	)
+	@RequestMapping(
+		value = "json/{profile}",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.TEXT_PLAIN_VALUE
+	)
+	@ApiOperation(
+		value = "Transform HL7 to JSON",
+		notes = "Transforms an HL7 message to JSON object using a profile."
+	)
 	@ResponseBody
 	public ResponseEntity<?> transformHL7toJSON(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String message, 
-			@ApiParam(value = "Spec (HL7 or PHIN)", allowableValues = "hl7,phinms") @RequestParam(value = "spec", required = false) String spec, 
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile) {
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String message, 
+		@ApiParam(value = "Spec (HL7 or PHIN)", allowableValues = "hl7,phinms") @RequestParam(value = "spec", required = false) String spec, 
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_TRANSFORMHL7TOJSON);
 		log.put(MessageHelper.CONST_PROFILE, profile);
@@ -137,12 +159,24 @@ public class HL7Controller {
 		}
 	}
 
-	@RequestMapping(value = "caseId/{spec}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.TEXT_PLAIN_VALUE)
-	@ApiOperation(value = "Get case identifier", notes = "Get case identifier")
+	@RequestMapping(
+		value = "caseId/{spec}",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.TEXT_PLAIN_VALUE
+	)
+	@ApiOperation(
+		value = "Get case identifier",
+		notes = "Get case identifier"
+	)
 	@ResponseBody
-	public ResponseEntity<?> getCaseIdentifier(@RequestBody(required = true) String message, @ApiParam(value = "Spec (HL7 or PHIN)", allowableValues = "hl7,phinms", required = true) @PathVariable(value = "spec") String spec) {
+	public ResponseEntity<?> getCaseIdentifier(
+		@RequestBody(required = true) String message,
+		@ApiParam(value = "Spec (HL7 or PHIN)",
+		allowableValues = "hl7,phinms",
+		required = true) @PathVariable(value = "spec") String spec
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_GETCASEIDENTIFIER);
 
@@ -156,8 +190,16 @@ public class HL7Controller {
 		}
 	}
 
-	@RequestMapping(value = "hash", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.TEXT_PLAIN_VALUE)
-	@ApiOperation(value = "Get message hash", notes = "Get message hash")
+	@RequestMapping(
+		value = "hash",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.TEXT_PLAIN_VALUE
+	)
+	@ApiOperation(
+		value = "Get message hash",
+		notes = "Get message hash"
+	)
 	@ResponseBody
 	public ResponseEntity<?> getMessageHash(@RequestBody(required = true) String message) {
 		ObjectMapper mapper = new ObjectMapper();
@@ -180,11 +222,19 @@ public class HL7Controller {
 		}
 	}
 
-	@RequestMapping(value = "xml", method = RequestMethod.POST, produces = MediaType.APPLICATION_XML_VALUE)
-	@ApiOperation(value = "Transform HL7 to XML", notes = "Transforms an HL7 message to XML document.")
+	@RequestMapping(
+		value = "xml",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_XML_VALUE
+	)
+	@ApiOperation(
+		value = "Transform HL7 to XML",
+		notes = "Transforms an HL7 message to XML document."
+	)
 	@ResponseBody
-	public ResponseEntity<?> transformHL7toXML(@RequestBody(required = true) String message) throws HL7Exception {
-
+	public ResponseEntity<?> transformHL7toXML(
+		@RequestBody(required = true) String message
+	) throws HL7Exception {
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_TRANSFORMHL7TOXML);
 
@@ -232,11 +282,17 @@ public class HL7Controller {
 		}
 	}
 
-	@RequestMapping(value = "generate", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
-	@ApiOperation(value = "Generate random HL7 message", notes = "Generate random HL7 message.")
+	@RequestMapping(
+		value = "generate",
+		method = RequestMethod.GET,
+		produces = MediaType.TEXT_PLAIN_VALUE
+	)
+	@ApiOperation(
+		value = "Generate random HL7 message",
+		notes = "Generate random HL7 message."
+	)
 	@ResponseBody
 	public ResponseEntity<?> generate() {
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_GENERATE);
 

--- a/src/main/java/gov/cdc/foundation/controller/RulesValidationController.java
+++ b/src/main/java/gov/cdc/foundation/controller/RulesValidationController.java
@@ -51,13 +51,23 @@ public class RulesValidationController {
 	private String profileRegex;
 	private String profileSchemaPath;
 
-	public RulesValidationController(@Value("${profile.regex}") String profileRegex, @Value("${profile.schema.path}") String profileSchemaPath) {
+	public RulesValidationController(
+		@Value("${profile.regex}") String profileRegex,
+		@Value("${profile.schema.path}"
+	) String profileSchemaPath) {
 		this.profileRegex = profileRegex;
 		this.profileSchemaPath = profileSchemaPath;
 	}
 
-	@RequestMapping(value = "schema", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get rules schema", notes = "Get rules schema")
+	@RequestMapping(
+		value = "schema",
+		method = RequestMethod.GET,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Get rules schema",
+		notes = "Get rules schema"
+	)
 	@ResponseBody
 	public ResponseEntity<?> getRulesSchema() {
 		ObjectMapper mapper = new ObjectMapper();
@@ -78,8 +88,15 @@ public class RulesValidationController {
 		}
 	}
 
-	@RequestMapping(value = "check", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Check rules against the schema", notes = "Check rules against the schema")
+	@RequestMapping(
+		value = "check",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Check rules against the schema",
+		notes = "Check rules against the schema"
+	)
 	@ResponseBody
 	public ResponseEntity<?> checkRulesSyntax(@RequestBody(required = true) String payload) {
 
@@ -124,28 +141,58 @@ public class RulesValidationController {
 
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('hl7-utils:'.concat(#profile))")
-	@RequestMapping(value = "{profile}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified profile", notes = "Create or update rules")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.create')"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.update')"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.*')"
+	)
+	@RequestMapping(
+		value = "{profile}",
+		method = RequestMethod.PUT,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Create or update rules for the specified profile",
+		notes = "Create or update rules"
+	)
 	@ResponseBody
 	public ResponseEntity<?> upsertRulesWithPut(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String payload, 
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile) {
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String payload, 
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile
+	) {
 		return upsertRules(authorizationHeader, payload, profile);
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('hl7-utils:'.concat(#profile))")
-	@RequestMapping(value = "{profile}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified profile", notes = "Create or update rules")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.create')"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.update')"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.*')"
+	)
+	@RequestMapping(
+		value = "{profile}",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Create or update rules for the specified profile",
+		notes = "Create or update rules"
+	)
 	@ResponseBody
 	public ResponseEntity<?> upsertRules(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String payload, 
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String payload, 
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_UPSERTRULES);
 
@@ -188,17 +235,29 @@ public class RulesValidationController {
 
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('hl7-utils:'.concat(#profile))")
-	@RequestMapping(value = "{profile}/{ruleset}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get saved rules for the specified profile", notes = "Get saved rules")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.read')"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.*')"
+	)
+	@RequestMapping(
+		value = "{profile}/{ruleset}",
+		method = RequestMethod.GET,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Get saved rules for the specified profile",
+		notes = "Get saved rules"
+	)
 	@ResponseBody
 	public ResponseEntity<?> getRules(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile, 
-			@ApiParam(value = "Rule Set (such as `pii`, `warning` or `error`)") @PathVariable(value = "ruleset") String ruleset) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile, 
+		@ApiParam(value = "Rule Set (such as `pii`, `warning` or `error`)") @PathVariable(value = "ruleset") String ruleset
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_GETRULES);
 
@@ -221,15 +280,27 @@ public class RulesValidationController {
 
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('hl7-utils:'.concat(#profile))")
-	@RequestMapping(value = "validate/{profile}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.TEXT_PLAIN_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.read')"
+		+ " or #oauth2.hasScope('fdns.hl7-utils.*.*')"
+	)
+	@RequestMapping(
+		value = "validate/{profile}",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.TEXT_PLAIN_VALUE
+	)
 	@ApiOperation(value = "Validate HL7 message", notes = "Valides an HL7 message using JSON rules.")
 	@ResponseBody
 	public ResponseEntity<?> validate(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String payload, 
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile, 
-			@RequestParam(defaultValue = "false") boolean explain, @RequestParam(defaultValue = "false") boolean checkPII) {
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String payload, 
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile, 
+		@RequestParam(defaultValue = "false") boolean explain, @RequestParam(defaultValue = "false") boolean checkPII
+	) {
 		ObjectMapper mapper = new ObjectMapper();
 
 		Map<String, Object> log = new HashMap<>();
@@ -252,10 +323,26 @@ public class RulesValidationController {
 			statusObj.put("PII", json.get("PII"));
 
 			// Let's check the warnings
-			int nbOfWarnings = checkValidationRules(authorizationHeader, json, statusObj, profile, MessageHelper.CONST_WARNING, explain, explainationDetails);
+			int nbOfWarnings = checkValidationRules(
+				authorizationHeader,
+				json,
+				statusObj,
+				profile,
+				MessageHelper.CONST_WARNING,
+				explain,
+				explainationDetails
+			);
 
 			// Let's check the errors
-			int nbOfErrors = checkValidationRules(authorizationHeader, json, statusObj, profile, MessageHelper.CONST_ERROR, explain, explainationDetails);
+			int nbOfErrors = checkValidationRules(
+				authorizationHeader,
+				json,
+				statusObj,
+				profile,
+				MessageHelper.CONST_ERROR,
+				explain,
+				explainationDetails
+			);
 
 			responseObj.put(MessageHelper.CONST_VALID, nbOfErrors == 0);
 			responseObj.put("errors", nbOfErrors);
@@ -280,12 +367,20 @@ public class RulesValidationController {
 		}
 	}
 
-	private int checkValidationRules(String authorizationHeader, JSONObject payload, JSONObject statusObj, String profile, String ruleSet, boolean explain, JSONArray explainationDetails) throws ServiceException, ValidatorException {
+	private int checkValidationRules(
+		String authorizationHeader,
+		JSONObject payload,
+		JSONObject statusObj,
+		String profile,
+		String ruleSet,
+		boolean explain,
+		JSONArray explainationDetails
+	) throws ServiceException, ValidatorException {
 		int nbOfInvalidItems = 0;
-
 		JSONObject status = new JSONObject();
 		status.put(MessageHelper.CONST_CHECKED, true);
 		JSONObject rules = null;
+
 		try {
 			rules = ObjectHelper.getInstance(authorizationHeader).getObject(profile + "_" + ruleSet);
 			rules.remove("_id");
@@ -322,7 +417,11 @@ public class RulesValidationController {
 		return detail;
 	}
 
-	private List<ValidationResult> executeRules(JSONObject payload, JSONObject rules, JSONObject status) throws ServiceException, ValidatorException {
+	private List<ValidationResult> executeRules(
+		JSONObject payload,
+		JSONObject rules,
+		JSONObject status
+	) throws ServiceException, ValidatorException {
 		List<ValidationResult> checkList = null;
 		if (rules != null) {
 			status.put(MessageHelper.CONST_FOUNDPROFILE, true);

--- a/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
+++ b/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
@@ -35,7 +35,7 @@ public class OAuth2Configuration extends ResourceServerConfigurerAdapter {
 				.authorizeRequests()
 				.antMatchers(HttpMethod.OPTIONS).permitAll()
 				.antMatchers("/api/1.0/").permitAll()
-				.antMatchers(protectedURIs).access("#oauth2.hasScope('hl7-utils')")
+				.antMatchers(protectedURIs).access("#oauth2.hasScope('fdns.hl7-utils')")
 				.anyRequest().permitAll();
 		else
 			http

--- a/src/test/java/gov/cdc/foundation/HL7ApplicationTests.java
+++ b/src/test/java/gov/cdc/foundation/HL7ApplicationTests.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
-		"proxy.hostname=localhost",
+		"proxy.hostname=",
 		"security.oauth2.resource.user-info-uri=",
 		"security.oauth2.protected=",
 		"security.oauth2.client.client-id=",
@@ -51,7 +51,7 @@ public class HL7ApplicationTests {
 		JacksonTester.initFields(this, objectMapper);
 		
 		// Define the object URL
-		System.setProperty("OBJECT_URL", "http://fdns-ms-object:8083");
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
 	}
 
 	@Test

--- a/src/test/java/gov/cdc/foundation/OAuth2Test.java
+++ b/src/test/java/gov/cdc/foundation/OAuth2Test.java
@@ -2,6 +2,11 @@ package gov.cdc.foundation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,32 +15,98 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import gov.cdc.helper.RequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
-		"proxy.hostname=localhost",
-		"security.oauth2.resource.user-info-uri=",
-		"security.oauth2.protected=/**",
-		"security.oauth2.client.client-id=",
-		"security.oauth2.client.client-secret=",
+		"proxy.hostname=",
+		"security.oauth2.resource.user-info-uri=http://fdns-ms-stubbing:3002/oauth2/token/introspect",
+		"security.oauth2.protected=/api/1.0/**",
+		"security.oauth2.client.client-id=test",
+		"security.oauth2.client.client-secret=testsecret",
 		"ssl.verifying.disable=false" })
 public class OAuth2Test {
 
 	@Autowired
 	private TestRestTemplate restTemplate;
 	private String baseUrlPath = "/api/1.0/";
+	private String testToken = "Bearer testtoken";
 
-	@Test
-	public void indexPage() {
-		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath, String.class);
-		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	@Before
+	public void setup() throws Exception {
+		// Define the object URL
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
 	}
 	
 	@Test
-	public void generatePage() {
+	public void testUnauthenticated() {
 		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath + "generate", String.class);
 		assertThat(response.getStatusCodeValue()).isEqualTo(401);
+	}
+
+	@Test
+	public void testAthenticatedSpecific() throws Exception {
+		setScope("fdns.hl7-utils fdns.hl7-utils.myprofile.read");
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath + "json/myprofile",
+			HttpMethod.POST,
+			getHL7Entity("01.txt"),
+			String.class
+		);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	}
+
+	@Test
+	public void testAthenticatedWildcard() throws Exception {
+		setScope("fdns.hl7-utils fdns.hl7-utils.*.*");
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath + "json/myprofile",
+			HttpMethod.POST,
+			getHL7Entity("01.txt"),
+			String.class
+		);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	}
+
+	private void setScope(String scope) {
+		MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+		data.add("scope", scope);
+		RequestHelper.getInstance().executePost("http://fdns-ms-stubbing:3002/oauth2/mock", data);
+	}
+
+	private InputStream getResource(String path) throws IOException {
+		return getClass().getClassLoader().getResourceAsStream(path);
+	}
+
+	private String getResourceAsString(String path) throws IOException {
+		return IOUtils.toString(getResource(path));
+	}
+
+	private HttpEntity<String> getEntity(String content, MediaType mediaType) throws IOException {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", testToken);
+		headers.setContentType(mediaType);
+		HttpEntity<String> entity = new HttpEntity<String>(content, headers);
+		return entity;
+	}
+
+	private String getHL7(String filename) throws IOException {
+		return getResourceAsString("junit/hl7/" + filename);
+	}
+
+	private HttpEntity<String> getHL7Entity(String filename) throws IOException {
+		return getEntity(getHL7(filename), MediaType.TEXT_PLAIN);
 	}
 }

--- a/src/test/java/gov/cdc/foundation/RulesValidationTests.java
+++ b/src/test/java/gov/cdc/foundation/RulesValidationTests.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
-		"proxy.hostname=localhost",
+		"proxy.hostname=",
 		"security.oauth2.resource.user-info-uri=",
 		"security.oauth2.protected=",
 		"security.oauth2.client.client-id=",
@@ -51,7 +51,7 @@ public class RulesValidationTests {
 		JacksonTester.initFields(this, objectMapper);
 		
 		// Define the object URL
-		System.setProperty("OBJECT_URL", "http://fdns-ms-object:8083");
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
 	}
 
 	@Test


### PR DESCRIPTION
This pull request proposes a few changes:

- Changing the scopes to fall under a `fdns.*` namespace
- Adds support for CRUD operations (create, read, update and delete) and appends it at the end of the scope
- Adds support for wildcard scopes
- Adds the new https://github.com/CDCgov/fdns-ms-stubbing service for unit testing and tests OAuth 2.0 functionality